### PR TITLE
input, textline의 outline none 전역 css 설정

### DIFF
--- a/Kmarket_Html/Kmarket/css/style.css
+++ b/Kmarket_Html/Kmarket/css/style.css
@@ -8,6 +8,9 @@ a {
     text-decoration: none;
     color: #111;
 }
+input, textarea {
+    outline: none;
+}
 
 
 


### PR DESCRIPTION
/Kmarket/css/style.css의 textline, input의 outline을 none으로 하는 설정을 추가하였습니다.